### PR TITLE
Fixing code errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,46 @@ This version includes significant improvements:
 - ✅ **Cross-platform development** support
 - ✅ **Optimized dependencies** for faster, more reliable builds
 - ✅ **Automated setup** for quick development environment creation
+
+## Requirements
+
+- Python 3.8+
+- Kivy >=2.3.0
+- Buildozer (for Android builds)
+- Cython
+- setuptools >=60.0.0
+- python-for-android==2024.1.21
+- pywebview (for desktop support only, do NOT add to buildozer.spec)
+
+Install all requirements for desktop development:
+
+```sh
+pip install -r requirements.txt
+```
+
+For Android builds, ensure your `buildozer.spec` requirements line is:
+
+```
+requirements = python,kivy,pysdl2,openssl,zlib
+```
+
+**Do NOT add pywebview to buildozer.spec.**
+
+## Cross-Platform WebView Support
+
+- **Android:** Uses the native Android WebView via pyjnius (no kivy-garden.webview, no pywebview)
+- **Desktop (Windows, Linux, macOS):** Uses pywebview (opens in a separate window)
+
+## Running on Desktop
+
+```sh
+python main.py
+```
+This will launch the Kivy app and open the webview in a separate window (requires pywebview).
+
+## Building for Android
+
+```sh
+buildozer android debug
+```
+This will build the APK using the native Android WebView. Do not include pywebview in your buildozer.spec.

--- a/buildozer.spec
+++ b/buildozer.spec
@@ -34,7 +34,7 @@ version = 3.12
 
 # (list) Application requirements
 # comma separated e.g. requirements = sqlite3,kivy
-requirements = python,kivy,kivy-garden.webview,pysdl2,openssl,zlib
+requirements = python,kivy,pysdl2,openssl,zlib
 android.compile_options = -DOPENSSL_NO_SSL3
 
 # Explicitly set pyjnius source to ensure compatibility with Python 3
@@ -454,7 +454,7 @@ tests/*
 INTERNET
 
 [app:requirements@demo]
-python,kivy,kivy-garden.webview,pysdl2,openssl,zlib
+python,kivy,pysdl2,openssl,zlib
 
 [app:android.compile_options@demo]
 -DOPENSSL_NO_SSL3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
 # Core Kivy Framework
 kivy>=2.3.0
 
+# Desktop WebView support (do NOT add to buildozer.spec)
+pywebview
+
 # Build Tools  
 buildozer>=1.5.0
 cython>=0.29.33


### PR DESCRIPTION
Replace `kivy-garden.webview` with `pywebview` for desktop and native Android WebView, and update documentation.

The `kivy-garden.webview` repository is no longer available (404), making it unusable. This PR updates the project to use `pywebview` for desktop platforms and retains the native Android WebView via `pyjnius` for Android, ensuring continued and stable cross-platform web content display. Documentation (README and requirements.txt) is also updated to reflect these changes.

---

[Open in Web](https://www.cursor.com/agents?id=bc-6d301343-a112-43a2-a26b-a76f402bab7e) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-6d301343-a112-43a2-a26b-a76f402bab7e)